### PR TITLE
Use correct custom machine types

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ This documentation describes a list of rules available by enabling this ruleset.
 
 ### Invalid machine types
 
-These rules warn you if a machine type not listed at https://cloud.google.com/compute/docs/machine-types is being used. Please note that custom machine types cannot be detected correctly. These rules consider all machine types starting with `custom-` to be valid.
+These rules warn you if a machine type not listed at https://cloud.google.com/compute/docs/machine-types is being used. Please note that custom machine types cannot be detected correctly. These rules consider all machine types starting with `[e2|n2|n2d|n1]-custom-` to be valid.
 
 |Name|Severity|Enabled|
 | --- | --- | --- |

--- a/rules/google_composer_environment_invalid_machine_type.go
+++ b/rules/google_composer_environment_invalid_machine_type.go
@@ -64,7 +64,11 @@ func (r *GoogleComposerEnvironmentInvalidMachineTypeRule) Check(runner tflint.Ru
 				err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 				err = runner.EnsureNoError(err, func() error {
-					if validMachineTypes[machineType] || strings.HasPrefix(machineType, "custom-") {
+					if validMachineTypes[machineType] || 
+						strings.HasPrefix(machineType, "e2-custom-") ||
+						strings.HasPrefix(machineType, "n2-custom-") ||
+						strings.HasPrefix(machineType, "n2d-custom-") ||
+						strings.HasPrefix(machineType, "n1-custom-") {
 						return nil
 					}
 

--- a/rules/google_composer_environment_invalid_machine_type_test.go
+++ b/rules/google_composer_environment_invalid_machine_type_test.go
@@ -82,7 +82,7 @@ resource "google_composer_environment" "test" {
 
     node_config {
       zone         = "us-central1-a"
-      machine_type = "custom-6-20480"
+      machine_type = "n2-custom-6-20480"
 
       network    = google_compute_network.test.id
       subnetwork = google_compute_subnetwork.test.id

--- a/rules/google_compute_instance_invalid_machine_type.go
+++ b/rules/google_compute_instance_invalid_machine_type.go
@@ -43,7 +43,11 @@ func (r *GoogleComputeInstanceInvalidMachineTypeRule) Check(runner tflint.Runner
 		err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 		return runner.EnsureNoError(err, func() error {
-			if validMachineTypes[machineType] || strings.HasPrefix(machineType, "custom-") {
+			if validMachineTypes[machineType] ||
+				strings.HasPrefix(machineType, "e2-custom-") ||
+				strings.HasPrefix(machineType, "n2-custom-") ||
+				strings.HasPrefix(machineType, "n2d-custom-") ||
+				strings.HasPrefix(machineType, "n1-custom-") {
 				return nil
 			}
 

--- a/rules/google_compute_instance_invalid_machine_type_test.go
+++ b/rules/google_compute_instance_invalid_machine_type_test.go
@@ -43,7 +43,7 @@ resource "google_compute_instance" "vm_instance" {
 			Name: "custom type",
 			Content: `
 resource "google_compute_instance" "vm_instance" {
-    machine_type = "custom-6-20480"
+    machine_type = "n2-custom-6-20480"
 }`,
 			Expected: helper.Issues{},
 		},

--- a/rules/google_compute_instance_template_invalid_machine_type.go
+++ b/rules/google_compute_instance_template_invalid_machine_type.go
@@ -43,7 +43,11 @@ func (r *GoogleComputeInstanceTemplateInvalidMachineTypeRule) Check(runner tflin
 		err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 		return runner.EnsureNoError(err, func() error {
-			if validMachineTypes[machineType] || strings.HasPrefix(machineType, "custom-") {
+			if validMachineTypes[machineType] ||
+				strings.HasPrefix(machineType, "e2-custom-") ||
+				strings.HasPrefix(machineType, "n2-custom-") ||
+				strings.HasPrefix(machineType, "n2d-custom-") ||
+				strings.HasPrefix(machineType, "n1-custom-") {
 				return nil
 			}
 

--- a/rules/google_compute_instance_template_invalid_machine_type_test.go
+++ b/rules/google_compute_instance_template_invalid_machine_type_test.go
@@ -43,7 +43,7 @@ resource "google_compute_instance_template" "vm_instance" {
 			Name: "custom type",
 			Content: `
 resource "google_compute_instance_template" "vm_instance" {
-    machine_type = "custom-6-20480"
+    machine_type = "n2-custom-6-20480"
 }`,
 			Expected: helper.Issues{},
 		},

--- a/rules/google_compute_reservation_invalid_machine_type.go
+++ b/rules/google_compute_reservation_invalid_machine_type.go
@@ -64,7 +64,11 @@ func (r *GoogleComputeReservationInvalidMachineTypeRule) Check(runner tflint.Run
 				err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 				err = runner.EnsureNoError(err, func() error {
-					if validMachineTypes[machineType] || strings.HasPrefix(machineType, "custom-") {
+					if validMachineTypes[machineType] ||
+						strings.HasPrefix(machineType, "e2-custom-") ||
+						strings.HasPrefix(machineType, "n2-custom-") ||
+						strings.HasPrefix(machineType, "n2d-custom-") ||
+						strings.HasPrefix(machineType, "n1-custom-") {
 						return nil
 					}
 

--- a/rules/google_compute_reservation_invalid_machine_type_test.go
+++ b/rules/google_compute_reservation_invalid_machine_type_test.go
@@ -68,7 +68,7 @@ resource "google_compute_reservation" "gce_reservation" {
     count = 1
     instance_properties {
       min_cpu_platform = "Intel Cascade Lake"
-      machine_type     = "custom-6-20480"
+      machine_type     = "n2-custom-6-20480"
     }
   }
 }`,

--- a/rules/google_container_cluster_invalid_machine_type.go
+++ b/rules/google_container_cluster_invalid_machine_type.go
@@ -53,7 +53,11 @@ func (r *GoogleContainerClusterInvalidMachineTypeRule) Check(runner tflint.Runne
 			err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 			return runner.EnsureNoError(err, func() error {
-				if validMachineTypes[machineType] || strings.HasPrefix(machineType, "custom-") {
+				if validMachineTypes[machineType] ||
+					strings.HasPrefix(machineType, "e2-custom-") ||
+					strings.HasPrefix(machineType, "n2-custom-") ||
+					strings.HasPrefix(machineType, "n2d-custom-") ||
+					strings.HasPrefix(machineType, "n1-custom-") {
 					return nil
 				}
 

--- a/rules/google_container_cluster_invalid_machine_type_test.go
+++ b/rules/google_container_cluster_invalid_machine_type_test.go
@@ -73,7 +73,7 @@ resource "google_container_cluster" "primary_preemptible_nodes" {
 
   node_config {
     preemptible  = true
-    machine_type = "custom-6-20480"
+    machine_type = "n2-custom-6-20480"
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",

--- a/rules/google_container_node_pool_invalid_machine_type.go
+++ b/rules/google_container_node_pool_invalid_machine_type.go
@@ -53,7 +53,11 @@ func (r *GoogleContainerNodePoolInvalidMachineTypeRule) Check(runner tflint.Runn
 			err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 			return runner.EnsureNoError(err, func() error {
-				if validMachineTypes[machineType] || strings.HasPrefix(machineType, "custom-") {
+				if validMachineTypes[machineType] ||
+					strings.HasPrefix(machineType, "e2-custom-") ||
+					strings.HasPrefix(machineType, "n2-custom-") ||
+					strings.HasPrefix(machineType, "n2d-custom-") ||
+					strings.HasPrefix(machineType, "n1-custom-") {
 					return nil
 				}
 

--- a/rules/google_container_node_pool_invalid_machine_type_test.go
+++ b/rules/google_container_node_pool_invalid_machine_type_test.go
@@ -76,7 +76,7 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
 
   node_config {
     preemptible  = true
-    machine_type = "custom-6-20480"
+    machine_type = "n2-custom-6-20480"
 
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",

--- a/rules/google_dataflow_job_invalid_machine_type.go
+++ b/rules/google_dataflow_job_invalid_machine_type.go
@@ -43,7 +43,11 @@ func (r *GoogleDataflowJobInvalidMachineTypeRule) Check(runner tflint.Runner) er
 		err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 		return runner.EnsureNoError(err, func() error {
-			if validMachineTypes[machineType] || strings.HasPrefix(machineType, "custom-") {
+			if validMachineTypes[machineType] ||
+				strings.HasPrefix(machineType, "e2-custom-") ||
+				strings.HasPrefix(machineType, "n2-custom-") ||
+				strings.HasPrefix(machineType, "n2d-custom-") ||
+				strings.HasPrefix(machineType, "n1-custom-") {
 				return nil
 			}
 

--- a/rules/google_dataflow_job_invalid_machine_type_test.go
+++ b/rules/google_dataflow_job_invalid_machine_type_test.go
@@ -43,7 +43,7 @@ resource "google_dataflow_job" "vm_instance" {
 			Name: "custom type",
 			Content: `
 resource "google_dataflow_job" "vm_instance" {
-    machine_type = "custom-6-20480"
+    machine_type = "n2-custom-6-20480"
 }`,
 			Expected: helper.Issues{},
 		},


### PR DESCRIPTION
It seems like the custom machine types are starting with `[e2|n2|n2d|n1]-custom-`  instead of `custom-`. 

There are currently four possible prefixes according to GCP's document.
https://cloud.google.com/compute/docs/machine-types#custom_machine_types
