### PR TITLE
Make custom-* valid custom type

### DIFF
--- a/rules/google_composer_environment_invalid_machine_type.go
+++ b/rules/google_composer_environment_invalid_machine_type.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"fmt"
-	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -64,11 +63,7 @@ func (r *GoogleComposerEnvironmentInvalidMachineTypeRule) Check(runner tflint.Ru
 				err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 				err = runner.EnsureNoError(err, func() error {
-					if validMachineTypes[machineType] || 
-						strings.HasPrefix(machineType, "e2-custom-") ||
-						strings.HasPrefix(machineType, "n2-custom-") ||
-						strings.HasPrefix(machineType, "n2d-custom-") ||
-						strings.HasPrefix(machineType, "n1-custom-") {
+					if validMachineTypes[machineType] || isCustomType(machineType) {
 						return nil
 					}
 

--- a/rules/google_compute_instance_invalid_machine_type.go
+++ b/rules/google_compute_instance_invalid_machine_type.go
@@ -2,14 +2,13 @@ package rules
 
 import (
 	"fmt"
-	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
 // GoogleComputeInstanceInvalidMachineTypeRule checks whether the machine type is invalid
-type GoogleComputeInstanceInvalidMachineTypeRule struct {}
+type GoogleComputeInstanceInvalidMachineTypeRule struct{}
 
 // NewGoogleComputeInstanceInvalidMachineTypeRule returns a new rule
 func NewGoogleComputeInstanceInvalidMachineTypeRule() *GoogleComputeInstanceInvalidMachineTypeRule {
@@ -43,11 +42,7 @@ func (r *GoogleComputeInstanceInvalidMachineTypeRule) Check(runner tflint.Runner
 		err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 		return runner.EnsureNoError(err, func() error {
-			if validMachineTypes[machineType] ||
-				strings.HasPrefix(machineType, "e2-custom-") ||
-				strings.HasPrefix(machineType, "n2-custom-") ||
-				strings.HasPrefix(machineType, "n2d-custom-") ||
-				strings.HasPrefix(machineType, "n1-custom-") {
+			if validMachineTypes[machineType] || isCustomType(machineType) {
 				return nil
 			}
 

--- a/rules/google_compute_instance_template_invalid_machine_type.go
+++ b/rules/google_compute_instance_template_invalid_machine_type.go
@@ -2,14 +2,13 @@ package rules
 
 import (
 	"fmt"
-	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
 // GoogleComputeInstanceTemplateInvalidMachineTypeRule checks whether the machine type is invalid
-type GoogleComputeInstanceTemplateInvalidMachineTypeRule struct {}
+type GoogleComputeInstanceTemplateInvalidMachineTypeRule struct{}
 
 // NewGoogleComputeInstanceTemplateInvalidMachineTypeRule returns a new rule
 func NewGoogleComputeInstanceTemplateInvalidMachineTypeRule() *GoogleComputeInstanceTemplateInvalidMachineTypeRule {
@@ -43,11 +42,7 @@ func (r *GoogleComputeInstanceTemplateInvalidMachineTypeRule) Check(runner tflin
 		err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 		return runner.EnsureNoError(err, func() error {
-			if validMachineTypes[machineType] ||
-				strings.HasPrefix(machineType, "e2-custom-") ||
-				strings.HasPrefix(machineType, "n2-custom-") ||
-				strings.HasPrefix(machineType, "n2d-custom-") ||
-				strings.HasPrefix(machineType, "n1-custom-") {
+			if validMachineTypes[machineType] || isCustomType(machineType) {
 				return nil
 			}
 

--- a/rules/google_compute_reservation_invalid_machine_type.go
+++ b/rules/google_compute_reservation_invalid_machine_type.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"fmt"
-	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -64,11 +63,7 @@ func (r *GoogleComputeReservationInvalidMachineTypeRule) Check(runner tflint.Run
 				err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 				err = runner.EnsureNoError(err, func() error {
-					if validMachineTypes[machineType] ||
-						strings.HasPrefix(machineType, "e2-custom-") ||
-						strings.HasPrefix(machineType, "n2-custom-") ||
-						strings.HasPrefix(machineType, "n2d-custom-") ||
-						strings.HasPrefix(machineType, "n1-custom-") {
+					if validMachineTypes[machineType] || isCustomType(machineType) {
 						return nil
 					}
 

--- a/rules/google_container_cluster_invalid_machine_type.go
+++ b/rules/google_container_cluster_invalid_machine_type.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"fmt"
-	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -53,11 +52,7 @@ func (r *GoogleContainerClusterInvalidMachineTypeRule) Check(runner tflint.Runne
 			err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 			return runner.EnsureNoError(err, func() error {
-				if validMachineTypes[machineType] ||
-					strings.HasPrefix(machineType, "e2-custom-") ||
-					strings.HasPrefix(machineType, "n2-custom-") ||
-					strings.HasPrefix(machineType, "n2d-custom-") ||
-					strings.HasPrefix(machineType, "n1-custom-") {
+				if validMachineTypes[machineType] || isCustomType(machineType) {
 					return nil
 				}
 

--- a/rules/google_container_node_pool_invalid_machine_type.go
+++ b/rules/google_container_node_pool_invalid_machine_type.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"fmt"
-	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -53,11 +52,7 @@ func (r *GoogleContainerNodePoolInvalidMachineTypeRule) Check(runner tflint.Runn
 			err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 			return runner.EnsureNoError(err, func() error {
-				if validMachineTypes[machineType] ||
-					strings.HasPrefix(machineType, "e2-custom-") ||
-					strings.HasPrefix(machineType, "n2-custom-") ||
-					strings.HasPrefix(machineType, "n2d-custom-") ||
-					strings.HasPrefix(machineType, "n1-custom-") {
+				if validMachineTypes[machineType] || isCustomType(machineType) {
 					return nil
 				}
 

--- a/rules/google_dataflow_job_invalid_machine_type.go
+++ b/rules/google_dataflow_job_invalid_machine_type.go
@@ -2,14 +2,13 @@ package rules
 
 import (
 	"fmt"
-	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
 // GoogleDataflowJobInvalidMachineTypeRule checks whether the machine type is invalid
-type GoogleDataflowJobInvalidMachineTypeRule struct {}
+type GoogleDataflowJobInvalidMachineTypeRule struct{}
 
 // NewGoogleDataflowJobInvalidMachineTypeRule returns a new rule
 func NewGoogleDataflowJobInvalidMachineTypeRule() *GoogleDataflowJobInvalidMachineTypeRule {
@@ -43,11 +42,7 @@ func (r *GoogleDataflowJobInvalidMachineTypeRule) Check(runner tflint.Runner) er
 		err := runner.EvaluateExpr(attribute.Expr, &machineType)
 
 		return runner.EnsureNoError(err, func() error {
-			if validMachineTypes[machineType] ||
-				strings.HasPrefix(machineType, "e2-custom-") ||
-				strings.HasPrefix(machineType, "n2-custom-") ||
-				strings.HasPrefix(machineType, "n2d-custom-") ||
-				strings.HasPrefix(machineType, "n1-custom-") {
+			if validMachineTypes[machineType] || isCustomType(machineType) {
 				return nil
 			}
 

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -121,5 +121,6 @@ func isCustomType(machineType string) bool {
 	return strings.HasPrefix(machineType, "e2-custom-") ||
 		strings.HasPrefix(machineType, "n2-custom-") ||
 		strings.HasPrefix(machineType, "n2d-custom-") ||
-		strings.HasPrefix(machineType, "n1-custom-")
+		strings.HasPrefix(machineType, "n1-custom-") ||
+		strings.HasPrefix(machineType, "custom-")
 }

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -1,5 +1,7 @@
 package rules
 
+import "strings"
+
 var validMachineTypes = map[string]bool{
 	"e2-standard-2":    true,
 	"e2-standard-4":    true,
@@ -113,4 +115,11 @@ var validMachineTypes = map[string]bool{
 	"e2-medium":        true,
 	"f1-micro":         true,
 	"g1-small":         true,
+}
+
+func isCustomType(machineType string) bool {
+	return strings.HasPrefix(machineType, "e2-custom-") ||
+		strings.HasPrefix(machineType, "n2-custom-") ||
+		strings.HasPrefix(machineType, "n2d-custom-") ||
+		strings.HasPrefix(machineType, "n1-custom-")
 }


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-google/pull/45

`custom-*` is also a valid custom type. It's is the same as `n1-custom-*`
See https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type#create