### PR TITLE
Stop using set-env commands

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         version: [v0.20.1, latest]
+    env:
+      TFLINT_VERSION: ${{ matrix.version }}
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -25,9 +27,6 @@ jobs:
       uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.15
-    - name: Set env
-      if: matrix.version != 'latest'
-      run: echo "::set-env name=TFLINT_VERSION::${{ matrix.version }}"
     - name: Install TFLint
       run: curl -sL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
     - name: Install plugin (Linux)


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

GitHub announces the deprecation of `set-env` and `add-path` workflow commands. This pull request replaces the `set-env` command with `env` syntax.