### PR TITLE
rule: Add google_compute_resource_policy_invalid_name rule

### DIFF
--- a/rules/google_compute_resource_policy_invalid_name.go
+++ b/rules/google_compute_resource_policy_invalid_name.go
@@ -1,0 +1,58 @@
+package rules
+
+import (
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// GoogleComputeResourcePolicyInvalidNameRule checks whether the name is invalid
+type GoogleComputeResourcePolicyInvalidNameRule struct {
+	resourceType  string
+	attributeName string
+}
+
+// NewGoogleComputeResourcePolicyInvalidNameRule returns new rule with default attributes
+func NewGoogleComputeResourcePolicyInvalidNameRule() *GoogleComputeResourcePolicyInvalidNameRule {
+	return &GoogleComputeResourcePolicyInvalidNameRule{
+		resourceType:  "google_compute_resource_policy",
+		attributeName: "name",
+	}
+}
+
+// Name returns the rule name
+func (r *GoogleComputeResourcePolicyInvalidNameRule) Name() string {
+	return "google_compute_resource_policy_invalid_name"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *GoogleComputeResourcePolicyInvalidNameRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *GoogleComputeResourcePolicyInvalidNameRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *GoogleComputeResourcePolicyInvalidNameRule) Link() string {
+	return ""
+}
+
+// Check checks whether the name is invalid
+func (r *GoogleComputeResourcePolicyInvalidNameRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
+
+		validateFunc := validateRegexp(`^[a-z]([-a-z0-9]*[a-z0-9])$`)
+
+		return runner.EnsureNoError(err, func() error {
+			_, errors := validateFunc(val, r.attributeName)
+			for _, err := range errors {
+				runner.EmitIssueOnExpr(r, err.Error(), attribute.Expr)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/google_compute_resource_policy_invalid_name_test.go
+++ b/rules/google_compute_resource_policy_invalid_name_test.go
@@ -1,0 +1,48 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_GoogleComputeResourcePolicyInvalidName(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "basic",
+			Content: `
+resource "google_compute_resource_policy" "snapshot_policy" {
+  name = "snapshot_policy"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewGoogleComputeResourcePolicyInvalidNameRule(),
+					Message: `"name" ("snapshot_policy") doesn't match regexp "^[a-z]([-a-z0-9]*[a-z0-9])$"`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 10},
+						End:      hcl.Pos{Line: 3, Column: 27},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewGoogleComputeResourcePolicyInvalidNameRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -14,4 +14,5 @@ var Rules = append([]tflint.Rule{
 	NewGoogleContainerClusterInvalidMachineTypeRule(),
 	NewGoogleContainerNodePoolInvalidMachineTypeRule(),
 	NewGoogleDataflowJobInvalidMachineTypeRule(),
+	NewGoogleComputeResourcePolicyInvalidNameRule(),
 }, magicmodules.Rules...)

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -1,6 +1,12 @@
 package rules
 
-import "strings"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
 
 var validMachineTypes = map[string]bool{
 	"e2-standard-2":    true,
@@ -123,4 +129,16 @@ func isCustomType(machineType string) bool {
 		strings.HasPrefix(machineType, "n2d-custom-") ||
 		strings.HasPrefix(machineType, "n1-custom-") ||
 		strings.HasPrefix(machineType, "custom-")
+}
+
+func validateRegexp(re string) schema.SchemaValidateFunc {
+	return func(v interface{}, k string) (ws []string, errors []error) {
+		value := v.(string)
+		if !regexp.MustCompile(re).MatchString(value) {
+			errors = append(errors, fmt.Errorf(
+				"%q (%q) doesn't match regexp %q", k, value, re))
+		}
+
+		return
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-ruleset-google/issues/66
See also https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy#name

Output example:

```console
Error: "name" ("snapshot_policy") doesn't match regexp "^[a-z]([-a-z0-9]*[a-z0-9])$" (google_compute_resource_policy_invalid_name)

  on template.tf line 2:
   2:   name   = "snapshot_policy"
```