### PR TITLE
build: Add support for darwin/arm64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Go
       uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.16
     - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: v0.169.0
+        args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        VERSION: v0.143.0
-      run: curl -sL https://git.io/goreleaser | bash

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
       - 386
       - amd64
       - arm
+      - arm64
 archives:
   - id: zip
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
This PR adds `arm64` as GOARCH to support darwin/arm64 (Apple M1) build. And switch to goreleaser-action from the custom script and update GoReleaser version to the latest.