### PR TITLE
Add google_project_iam_member_invalid_member_format rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -20,7 +20,7 @@ These rules warn you if a machine type not listed at https://cloud.google.com/co
 
 ### Invalid member format
 
-TODO
+This rule warn you if a member value in IAM related resources is invalid. 
 
 |Name|Severity|Enabled|
 | --- | --- | --- |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -18,6 +18,14 @@ These rules warn you if a machine type not listed at https://cloud.google.com/co
 |google_container_node_pool_invalid_machine_type|ERROR|✔|
 |google_dataflow_job_invalid_machine_type|ERROR|✔|
 
+### Invalid member format
+
+TODO
+
+|Name|Severity|Enabled|
+| --- | --- | --- |
+|google_project_iam_member_invalid_member_format|ERROR|✔|
+
 ## Magic Modules Rules
 
 These are the rules that warn against invalid values generated from [Magic Modules](https://github.com/terraform-linters/magic-modules). These rules are defined under the [`rules/magicmodules`](../../rules/magicmodules) directory.

--- a/docs/rules/google_project_iam_member_invalid_member_format.md
+++ b/docs/rules/google_project_iam_member_invalid_member_format.md
@@ -24,6 +24,20 @@ Error: jane@example.com is an invalid member format. (google_project_iam_member)
 ## Why
 
 A member value you wrote is invalid. `terraform apply` will result in failure.
+In particular, don't forget to add a prefix to the value. Since the principal type is identified with a prefix, a value without a prefix cannot be interpreted correctly. There are two exceptions; `allUsers` and `allAuthenticatedUsers` are valid without a prefix. In conclusion, the valid member values are:
+
+- `allUsers`
+- `allAuthenticatedUsers`
+- `user:{emailid}`
+- `serviceAccount:{emailid}`
+- `group:{emailid}`
+- `domain:{domain}`
+
+See these documents in detail:
+
+ - https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#member/members
+ - https://cloud.google.com/iam/docs/overview#concepts_related_identity
+ - https://cloud.google.com/iam/docs/overview#cloud-iam-policy
 
 ## How To Fix
 

--- a/docs/rules/google_project_iam_member_invalid_member_format.md
+++ b/docs/rules/google_project_iam_member_invalid_member_format.md
@@ -27,4 +27,10 @@ A member value you wrote is invalid. `terraform apply` will result in failure.
 
 ## How To Fix
 
-See the document. Probably you just need to add some prefixes.
+See the document. Probably you just need to add some prefixes. The example can be fixed as below:
+
+```hcl
+resource "google_project_iam_member" "iam_member" {
+	member = "user:jane@example.com"
+}
+```

--- a/docs/rules/google_project_iam_member_invalid_member_format.md
+++ b/docs/rules/google_project_iam_member_invalid_member_format.md
@@ -1,0 +1,30 @@
+# google_project_iam_member_invalid_member_format
+
+Check iam member format.
+
+## Example
+
+```hcl
+resource "google_project_iam_member" "iam_member" {
+	member = "jane@example.com"
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Error: jane@example.com is an invalid member format. (google_project_iam_member)
+
+  on template.tf line 1:
+   1: resource "google_project_iam_member" "iam_member" {
+
+```
+
+## Why
+
+A member value you wrote is invalid. `terraform apply` will result in failure.
+
+## How To Fix
+
+See the document. Probably you just need to add some prefixes.

--- a/rules/google_project_iam_member_invalid_member_format.go
+++ b/rules/google_project_iam_member_invalid_member_format.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	hcl "github.com/hashicorp/hcl/v2"
-	"github.com/terraform-linters/tflint-plugin-sdk/project"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-google/project"
 )
 
 // GoogleProjectIamMemberInvalidMemberFormatRule checks whether member value is invalid

--- a/rules/google_project_iam_member_invalid_member_format.go
+++ b/rules/google_project_iam_member_invalid_member_format.go
@@ -1,0 +1,56 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// GoogleProjectIamMemberInvalidMemberFormatRule checks whether member value is invalid
+type GoogleProjectIamMemberInvalidMemberFormatRule struct{}
+
+// NewGoogleProjectIamMemberInvalidMemberFormatRule returns new rule with default attributes
+func NewGoogleProjectIamMemberInvalidMemberFormatRule() *GoogleProjectIamMemberInvalidMemberFormatRule {
+	return &GoogleProjectIamMemberInvalidMemberFormatRule{}
+}
+
+// Name returns the rule name
+func (r *GoogleProjectIamMemberInvalidMemberFormatRule) Name() string {
+	return "google_project_iam_member_invalid_member_format"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *GoogleProjectIamMemberInvalidMemberFormatRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *GoogleProjectIamMemberInvalidMemberFormatRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *GoogleProjectIamMemberInvalidMemberFormatRule) Link() string {
+	return iamMemberFormatDocumentLink
+}
+
+// Check checks whether member format is invalid
+func (r *GoogleProjectIamMemberInvalidMemberFormatRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes("google_project_iam_member", "member", func(attribute *hcl.Attribute) error {
+
+		var member string
+		err := runner.EvaluateExpr(attribute.Expr, &member, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			if isValidIAMMemberFormat(member) {
+				return nil
+			}
+			return runner.EmitIssueOnExpr(
+				r,
+				fmt.Sprintf("%s is an invalid member format", member),
+				attribute.Expr,
+			)
+		})
+	})
+}

--- a/rules/google_project_iam_member_invalid_member_format.go
+++ b/rules/google_project_iam_member_invalid_member_format.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/project"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
@@ -32,7 +33,7 @@ func (r *GoogleProjectIamMemberInvalidMemberFormatRule) Severity() string {
 
 // Link returns the rule reference link
 func (r *GoogleProjectIamMemberInvalidMemberFormatRule) Link() string {
-	return iamMemberFormatDocumentLink
+	return project.ReferenceLink(r.Name())
 }
 
 // Check checks whether member format is invalid

--- a/rules/google_project_iam_member_invalid_member_format_test.go
+++ b/rules/google_project_iam_member_invalid_member_format_test.go
@@ -1,0 +1,57 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_GoogleProjectIamMemberInvalidMemberFormat(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "invalid member",
+			Content: `
+resource "google_project_iam_member" "iam_member" {
+	member = "jane@example.com"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewGoogleProjectIamMemberInvalidMemberFormatRule(),
+					Message: "jane@example.com is an invalid member format",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 11},
+						End:      hcl.Pos{Line: 3, Column: 29},
+					},
+				},
+			},
+		},
+		{
+			Name: "valid member",
+			Content: `
+resource "google_project_iam_member" "iam_member" {
+	member = "user:jane@example.com"
+}
+`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewGoogleProjectIamMemberInvalidMemberFormatRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/google_project_iam_member_invalid_member_format_test.go
+++ b/rules/google_project_iam_member_invalid_member_format_test.go
@@ -41,6 +41,15 @@ resource "google_project_iam_member" "iam_member" {
 `,
 			Expected: helper.Issues{},
 		},
+		{
+			Name: "valid member",
+			Content: `
+resource "google_project_iam_member" "iam_member" {
+	member = "allUsers"
+}
+`,
+			Expected: helper.Issues{},
+		},
 	}
 
 	rule := NewGoogleProjectIamMemberInvalidMemberFormatRule()

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -15,4 +15,5 @@ var Rules = append([]tflint.Rule{
 	NewGoogleContainerNodePoolInvalidMachineTypeRule(),
 	NewGoogleDataflowJobInvalidMachineTypeRule(),
 	NewGoogleComputeResourcePolicyInvalidNameRule(),
+	NewGoogleProjectIamMemberInvalidMemberFormatRule(),
 }, magicmodules.Rules...)

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -143,8 +143,6 @@ func validateRegexp(re string) schema.SchemaValidateFunc {
 	}
 }
 
-var iamMemberFormatDocumentLink string = "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#member/members"
-
 func isValidIAMMemberFormat(s string) bool {
 	// See also https://cloud.google.com/iam/docs/overview
 	return s == "allUsers" ||

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -142,3 +142,12 @@ func validateRegexp(re string) schema.SchemaValidateFunc {
 		return
 	}
 }
+
+var iamMemberFormatDocumentLink string = "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#member/members"
+
+func isValidIAMMemberFormat(s string) bool {
+	return strings.HasPrefix(s, "user:") ||
+		strings.HasPrefix(s, "serviceAccount:") ||
+		strings.HasPrefix(s, "group:") ||
+		strings.HasPrefix(s, "domain:")
+}

--- a/rules/utils.go
+++ b/rules/utils.go
@@ -146,7 +146,10 @@ func validateRegexp(re string) schema.SchemaValidateFunc {
 var iamMemberFormatDocumentLink string = "https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#member/members"
 
 func isValidIAMMemberFormat(s string) bool {
-	return strings.HasPrefix(s, "user:") ||
+	// See also https://cloud.google.com/iam/docs/overview
+	return s == "allUsers" ||
+		s == "allAuthenticatedUsers" ||
+		strings.HasPrefix(s, "user:") ||
 		strings.HasPrefix(s, "serviceAccount:") ||
 		strings.HasPrefix(s, "group:") ||
 		strings.HasPrefix(s, "domain:")


### PR DESCRIPTION
I've been looking for a customizable terraform linter and found the tflint and this repository. 
Our infrastructure is on GCP and managed under terraform. One problem I'm facing happens when writing resources about IAM. IAM resources require some format https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#member/members but I and my colleagues often mistake dropping the prefixes. I want to prevent this mistake before executing `terraform apply`. 