### PR TITLE
Add more invalid_member_format rules

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -24,6 +24,7 @@ This rule warn you if a member value in IAM related resources is invalid.
 
 |Name|Severity|Enabled|
 | --- | --- | --- |
+|google_project_iam_audit_config_invalid_member_format|ERROR|✔|
 |google_project_iam_binding_invalid_member_format|ERROR|✔|
 |google_project_iam_member_invalid_member_format|ERROR|✔|
 |google_project_iam_policy_invalid_member_format|ERROR|✔|

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -24,6 +24,7 @@ This rule warn you if a member value in IAM related resources is invalid.
 
 |Name|Severity|Enabled|
 | --- | --- | --- |
+|google_project_iam_binding_invalid_member_format|ERROR|✔|
 |google_project_iam_member_invalid_member_format|ERROR|✔|
 
 ## Magic Modules Rules

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -26,6 +26,7 @@ This rule warn you if a member value in IAM related resources is invalid.
 | --- | --- | --- |
 |google_project_iam_binding_invalid_member_format|ERROR|✔|
 |google_project_iam_member_invalid_member_format|ERROR|✔|
+|google_project_iam_policy_invalid_member_format|ERROR|✔|
 
 ## Magic Modules Rules
 

--- a/docs/rules/google_project_iam_invalid_member_format.md
+++ b/docs/rules/google_project_iam_invalid_member_format.md
@@ -1,4 +1,4 @@
-# google_project_iam_member_invalid_member_format
+# google_project_iam_invalid_member_format
 
 Check iam member format.
 

--- a/rules/google_project_iam_audit_config_invalid_member.go
+++ b/rules/google_project_iam_audit_config_invalid_member.go
@@ -1,0 +1,78 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-google/project"
+)
+
+// GoogleProjectIamAuditConfigInvalidMemberRule checks whether member value is invalid
+type GoogleProjectIamAuditConfigInvalidMemberRule struct {
+	resourceType  string
+	blockName     string
+	attributeName string
+}
+
+func NewGoogleProjectIamAuditConfigInvalidMemberRule() *GoogleProjectIamAuditConfigInvalidMemberRule {
+	return &GoogleProjectIamAuditConfigInvalidMemberRule{
+		resourceType:  "google_project_iam_audit_config",
+		blockName:     "audit_log_config",
+		attributeName: "exempted_members",
+	}
+}
+
+// Name returns the rule name
+func (r *GoogleProjectIamAuditConfigInvalidMemberRule) Name() string {
+	return "google_project_iam_audit_config_invalid_member"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *GoogleProjectIamAuditConfigInvalidMemberRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *GoogleProjectIamAuditConfigInvalidMemberRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *GoogleProjectIamAuditConfigInvalidMemberRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether member format is invalid
+func (r *GoogleProjectIamAuditConfigInvalidMemberRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceBlocks(r.resourceType, r.blockName, func(block *hcl.Block) error {
+		content, _, diags := block.Body.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{Name: r.attributeName},
+			},
+		})
+		if diags.HasErrors() {
+			return diags
+		}
+
+		if attribute, exists := content.Attributes[r.attributeName]; exists {
+			var members []string
+			err := runner.EvaluateExpr(attribute.Expr, &members, nil)
+
+			return runner.EnsureNoError(err, func() error {
+				for _, member := range members {
+					if !isValidIAMMemberFormat(member) {
+						return runner.EmitIssueOnExpr(
+							r,
+							fmt.Sprintf("%s is an invalid member format", member),
+							attribute.Expr,
+						)
+					}
+				}
+				return nil
+			})
+		}
+
+		return nil
+	})
+}

--- a/rules/google_project_iam_audit_config_invalid_member_test.go
+++ b/rules/google_project_iam_audit_config_invalid_member_test.go
@@ -1,0 +1,65 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_GoogleProjectIamAuditConfigInvalidMember(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "invalid member",
+			Content: `
+resource "google_project_iam_audit_config" "iam_audit_config" {
+	audit_log_config {
+		exempted_members = [
+			"jane@example.com",
+		]
+	}
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewGoogleProjectIamAuditConfigInvalidMemberRule(),
+					Message: "jane@example.com is an invalid member format",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 4, Column: 22},
+						End:      hcl.Pos{Line: 6, Column: 4},
+					},
+				},
+			},
+		},
+		{
+			Name: "valid member",
+			Content: `
+resource "google_project_iam_audit_config" "iam_audit_config" {
+	audit_log_config {
+		exempted_members = [
+			"user:jane@example.com",
+		]
+	}
+}
+`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewGoogleProjectIamAuditConfigInvalidMemberRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/google_project_iam_binding_invalid_member.go
+++ b/rules/google_project_iam_binding_invalid_member.go
@@ -1,0 +1,64 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-google/project"
+)
+
+// GoogleProjectIamBindingInvalidMemberRule checks whether member value is invalid
+type GoogleProjectIamBindingInvalidMemberRule struct {
+	resourceType  string
+	attributeName string
+}
+
+// NewGoogleProjectIamBindingInvalidMemberRule returns new rule with default attributes
+func NewGoogleProjectIamBindingInvalidMemberRule() *GoogleProjectIamBindingInvalidMemberRule {
+	return &GoogleProjectIamBindingInvalidMemberRule{
+		resourceType:  "google_project_iam_binding",
+		attributeName: "members",
+	}
+}
+
+// Name returns the rule name
+func (r *GoogleProjectIamBindingInvalidMemberRule) Name() string {
+	return "google_project_iam_binding_invalid_member"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *GoogleProjectIamBindingInvalidMemberRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *GoogleProjectIamBindingInvalidMemberRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *GoogleProjectIamBindingInvalidMemberRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether member format is invalid
+func (r *GoogleProjectIamBindingInvalidMemberRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var members []string
+		err := runner.EvaluateExpr(attribute.Expr, &members, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			for _, member := range members {
+				if !isValidIAMMemberFormat(member) {
+					return runner.EmitIssueOnExpr(
+						r,
+						fmt.Sprintf("%s is an invalid member format", member),
+						attribute.Expr,
+					)
+				}
+			}
+			return nil
+		})
+	})
+}

--- a/rules/google_project_iam_binding_invalid_member_test.go
+++ b/rules/google_project_iam_binding_invalid_member_test.go
@@ -1,0 +1,61 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_GoogleProjectIamBindingInvalidMember(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "invalid member",
+			Content: `
+resource "google_project_iam_binding" "iam_binding" {
+	members = [
+		"jane@example.com",
+	]
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewGoogleProjectIamBindingInvalidMemberRule(),
+					Message: "jane@example.com is an invalid member format",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 5, Column: 3},
+					},
+				},
+			},
+		},
+		{
+			Name: "valid member",
+			Content: `
+resource "google_project_iam_binding" "iam_binding" {
+	members = [
+		"user:jane@example.com",
+	]
+}
+`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewGoogleProjectIamBindingInvalidMemberRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/google_project_iam_member_invalid_member_format.go
+++ b/rules/google_project_iam_member_invalid_member_format.go
@@ -9,11 +9,17 @@ import (
 )
 
 // GoogleProjectIamMemberInvalidMemberFormatRule checks whether member value is invalid
-type GoogleProjectIamMemberInvalidMemberFormatRule struct{}
+type GoogleProjectIamMemberInvalidMemberFormatRule struct {
+	resourceType  string
+	attributeName string
+}
 
 // NewGoogleProjectIamMemberInvalidMemberFormatRule returns new rule with default attributes
 func NewGoogleProjectIamMemberInvalidMemberFormatRule() *GoogleProjectIamMemberInvalidMemberFormatRule {
-	return &GoogleProjectIamMemberInvalidMemberFormatRule{}
+	return &GoogleProjectIamMemberInvalidMemberFormatRule{
+		resourceType:  "google_project_iam_member",
+		attributeName: "member",
+	}
 }
 
 // Name returns the rule name
@@ -38,7 +44,7 @@ func (r *GoogleProjectIamMemberInvalidMemberFormatRule) Link() string {
 
 // Check checks whether member format is invalid
 func (r *GoogleProjectIamMemberInvalidMemberFormatRule) Check(runner tflint.Runner) error {
-	return runner.WalkResourceAttributes("google_project_iam_member", "member", func(attribute *hcl.Attribute) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
 
 		var member string
 		err := runner.EvaluateExpr(attribute.Expr, &member, nil)

--- a/rules/google_project_iam_policy_invalid_member.go
+++ b/rules/google_project_iam_policy_invalid_member.go
@@ -1,0 +1,65 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint-ruleset-google/project"
+)
+
+// GoogleProjectIamPolicyInvalidMemberRule checks whether member value is invalid
+type GoogleProjectIamPolicyInvalidMemberRule struct {
+	resourceType  string
+	attributeName string
+}
+
+// NewGoogleProjectIamPolicyInvalidMemberRule returns new rule with default attributes
+func NewGoogleProjectIamPolicyInvalidMemberRule() *GoogleProjectIamPolicyInvalidMemberRule {
+	return &GoogleProjectIamPolicyInvalidMemberRule{
+		resourceType:  "google_project_iam_policy",
+		attributeName: "members",
+	}
+}
+
+// Name returns the rule name
+func (r *GoogleProjectIamPolicyInvalidMemberRule) Name() string {
+	return "google_project_iam_policy_invalid_member"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *GoogleProjectIamPolicyInvalidMemberRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *GoogleProjectIamPolicyInvalidMemberRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *GoogleProjectIamPolicyInvalidMemberRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether member format is invalid
+func (r *GoogleProjectIamPolicyInvalidMemberRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var members []string
+		err := runner.EvaluateExpr(attribute.Expr, &members, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			for _, member := range members {
+				if !isValidIAMMemberFormat(member) {
+					return runner.EmitIssueOnExpr(
+						r,
+						fmt.Sprintf("%s is an invalid member format", member),
+						attribute.Expr,
+					)
+				}
+
+			}
+			return nil
+		})
+	})
+}

--- a/rules/google_project_iam_policy_invalid_member_test.go
+++ b/rules/google_project_iam_policy_invalid_member_test.go
@@ -1,0 +1,61 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_GoogleProjectIamPolicyInvalidMember(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "invalid member",
+			Content: `
+resource "google_project_iam_policy" "iam_policy" {
+	members = [
+		"jane@example.com",
+	]
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewGoogleProjectIamPolicyInvalidMemberRule(),
+					Message: "jane@example.com is an invalid member format",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 5, Column: 3},
+					},
+				},
+			},
+		},
+		{
+			Name: "valid member",
+			Content: `
+resource "google_project_iam_policy" "iam_policy" {
+	members = [
+		"user:jane@example.com",
+	]
+}
+`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewGoogleProjectIamPolicyInvalidMemberRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -16,6 +16,7 @@ var Rules = append([]tflint.Rule{
 	NewGoogleDataflowJobInvalidMachineTypeRule(),
 	NewGoogleComputeResourcePolicyInvalidNameRule(),
 	NewGoogleProjectIamMemberInvalidMemberFormatRule(),
+	NewGoogleProjectIamAuditConfigInvalidMemberRule(),
 	NewGoogleProjectIamBindingInvalidMemberRule(),
 	NewGoogleProjectIamPolicyInvalidMemberRule(),
 }, magicmodules.Rules...)

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -17,4 +17,5 @@ var Rules = append([]tflint.Rule{
 	NewGoogleComputeResourcePolicyInvalidNameRule(),
 	NewGoogleProjectIamMemberInvalidMemberFormatRule(),
 	NewGoogleProjectIamBindingInvalidMemberRule(),
+	NewGoogleProjectIamPolicyInvalidMemberRule(),
 }, magicmodules.Rules...)

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -16,4 +16,5 @@ var Rules = append([]tflint.Rule{
 	NewGoogleDataflowJobInvalidMachineTypeRule(),
 	NewGoogleComputeResourcePolicyInvalidNameRule(),
 	NewGoogleProjectIamMemberInvalidMemberFormatRule(),
+	NewGoogleProjectIamBindingInvalidMemberRule(),
 }, magicmodules.Rules...)


### PR DESCRIPTION
Cont https://github.com/terraform-linters/tflint-ruleset-google/pull/121

Apply invalid_member_format rules to other IAM resources in the same way. Also did some refactoring.