### PR TITLE
add a2 variants and information about machine type documentation

### DIFF
--- a/rules/utils.go
+++ b/rules/utils.go
@@ -9,6 +9,7 @@ import (
 )
 
 var validMachineTypes = map[string]bool{
+	// Regular machine types: https://cloud.google.com/compute/docs/machine-types
 	"e2-standard-2":    true,
 	"e2-standard-4":    true,
 	"e2-standard-8":    true,
@@ -121,6 +122,13 @@ var validMachineTypes = map[string]bool{
 	"e2-medium":        true,
 	"f1-micro":         true,
 	"g1-small":         true,
+
+	// A100 machine types: https://cloud.google.com/compute/docs/gpus
+	"a2-highgpu-1g":  true,
+	"a2-highgpu-2g":  true,
+	"a2-highgpu-4g":  true,
+	"a2-highgpu-8g":  true,
+	"a2-megagpu-16g": true,
 }
 
 func isCustomType(machineType string) bool {


### PR DESCRIPTION
Optimally we'd also reject if the machine isn't in a valid zone, but it wasn't quite as straight forward so I'm leaving it as "future work". If there's a good example of cross-validating two fields, I'll happily do it as part of this PR.