### PR TITLE
Suppress unevaluable/unknown/null errors on provider block eval

### DIFF
--- a/google/provider.go
+++ b/google/provider.go
@@ -41,7 +41,7 @@ func GetProject(runner tflint.Runner) (string, error) {
 
 		if attr, exists := provider.Body.Attributes["project"]; exists {
 			var project string
-			if err := runner.EvaluateExpr(attr.Expr, &project, opts); err != nil {
+			if err := runner.EnsureNoError(runner.EvaluateExpr(attr.Expr, &project, opts), func() error { return nil }); err != nil {
 				return project, err
 			}
 		}


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-aws/pull/327

This bug also exists in the Google ruleset. This PR fixes a bug related to provider evaluation.