### PR TITLE
feat: add H100 machine-type to ruleset

### DIFF
--- a/rules/utils.go
+++ b/rules/utils.go
@@ -249,6 +249,9 @@ var validMachineTypes = map[string]bool{
 	"a2-ultragpu-4g": true,
 	"a2-ultragpu-8g": true,
 
+	// H100 machine types: https://cloud.google.com/compute/docs/gpus#h100-gpus
+	"a3-highgpu-8g": true,
+
 	// L4 machine types: https://cloud.google.com/compute/docs/gpus#l4-gpus
 	"g2-standard-4":  true,
 	"g2-standard-8":  true,


### PR DESCRIPTION
https://cloud.google.com/compute/docs/gpus#h100-gpus