### PR TITLE
feat: add one more H100 machine-type a3-megagpu-8g to ruleset

### DIFF
--- a/rules/utils.go
+++ b/rules/utils.go
@@ -285,6 +285,7 @@ var validMachineTypes = map[string]bool{
 
 	// H100 machine types: https://cloud.google.com/compute/docs/gpus#h100-gpus
 	"a3-highgpu-8g": true,
+	"a3-megagpu-8g": true,
 
 	// L4 machine types: https://cloud.google.com/compute/docs/gpus#l4-gpus
 	"g2-standard-4":  true,


### PR DESCRIPTION
`a3-megagpu-8g` is added recently