### PR TITLE
Remove unneeded repository info from goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,8 +42,6 @@ signs:
       - --yes
 release:
   github:
-    owner: terraform-linters
-    name: tflint-ruleset-google
   draft: true
 snapshot:
   version_template: "{{ .Tag }}-dev"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-linters/tflint-ruleset-google
 
-go 1.24.2
+go 1.24.6
 
 require (
 	github.com/dave/dst v0.27.3


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-opa/pull/167